### PR TITLE
fix: parsed colors now have correct opacity

### DIFF
--- a/lib/ansi_richtext_parser/colorscheme.dart
+++ b/lib/ansi_richtext_parser/colorscheme.dart
@@ -331,7 +331,7 @@ final _brightWhites = [
   (255, 255, 255),
 ];
 
-Color _toColor(tuple, {int alpha = 1}) {
+Color _toColor(tuple, {int alpha = 255}) {
   var (int r, int g, int b) = tuple;
   return Color.fromARGB(alpha, r, g, b);
 }


### PR DESCRIPTION
Previously, the parsed color used 1 instead of 255 as `a` parameter with Color.fromARGB which resulted in colored TextSpans that were actually invisible because their resulting opacity was 0.0039 instead of 1.

Color.fromARGB: `a` is the alpha value, with 0 being transparent and 255 being fully opaque.